### PR TITLE
add theme colors to flat ui dark peek view

### DIFF
--- a/themes/flatDark.json
+++ b/themes/flatDark.json
@@ -2,6 +2,20 @@
 	"name": "flat-ui",
 	"tokenColors": "./flatDark.tmTheme",
 	"colors": {
-		"titleBar.activeBackground": "#252526"
+		"titleBar.activeBackground": "#252526",
+		// peek view
+		"peekView.border": "#3c424c",
+		"peekViewEditor.background": "#222",
+		"peekViewEditorGutter.background": "#222",
+		"peekViewEditor.matchHighlightBackground": "#3c424c",
+		"peekViewResult.background": "#252526",
+		"peekViewResult.fileForeground": "#ddd",
+		"peekViewResult.lineForeground": "#ddd",
+		"peekViewResult.matchHighlightBackground": "#3c424c",
+		"peekViewResult.selectionBackground": "#3c424c",
+		"peekViewResult.selectionForeground": "#ddd",
+		"peekViewTitle.background": "#252526",
+		"peekViewTitleLabel.foreground": "#ddd",
+		"peekViewTitleDescription.foreground": "#ddd"
 	}
 }


### PR DESCRIPTION
This PR adds in the flat UI dark theme to the peek view. I tried to match the colors as much as I could.

Please advise on color changes if any needs to be done.

Previous take in colors of the previous peek preview theme
<img width="1680" alt="screen shot 2018-12-22 at 13 52 54" src="https://user-images.githubusercontent.com/3910877/50373491-f3146200-05f0-11e9-84ac-3f13354eee9d.png">

Current/New
<img width="1680" alt="screen shot 2018-12-22 at 13 51 36" src="https://user-images.githubusercontent.com/3910877/50373496-00315100-05f1-11e9-80c1-d2d0ad22fe73.png">


